### PR TITLE
Fixed HasControl() to check for Control, not Shift

### DIFF
--- a/key_event.go
+++ b/key_event.go
@@ -25,7 +25,7 @@ func (e KeyEvent) HasShift() bool {
 
 // HasControl reports whether e contains any 'ctrl' modifier.
 func (e KeyEvent) HasControl() bool {
-	return e.Modifiers.HasModifiers(ModifierShift)
+	return e.Modifiers.HasModifiers(ModifierControl)
 }
 
 // HasMenu reports whether e contains any 'alt' modifier.


### PR DESCRIPTION
The HasControl() function is currently checking for the ModifierShift modifier instead of ModifierControl